### PR TITLE
[Feat/api-response] 공통 API Response 구현

### DIFF
--- a/src/main/kotlin/com/fesi/flowit/common/dummy/ApiExample.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/dummy/ApiExample.kt
@@ -1,9 +1,10 @@
 package com.fesi.flowit.common.dummy
 
+import com.fesi.flowit.common.response.ApiResponse
+import com.fesi.flowit.common.response.ApiResult
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
-import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -17,6 +18,12 @@ data class DummyDto(
     val age: Int
 )
 
+data class DummyResDto(
+    val name: String,
+    val age: Int,
+    val msg: String
+)
+
 @RestController
 class ApiExample {
 
@@ -27,7 +34,7 @@ class ApiExample {
     )
     @ApiResponses(
         value = [
-            ApiResponse(
+            io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
                 description = "요청 성공",
                 content = [Content(
@@ -37,8 +44,8 @@ class ApiExample {
             )
         ]
     )
-    fun getExample(@PathVariable id: Int): ResponseEntity<String> {
-        return ResponseEntity.ok("GET > $id")
+    fun getExample(@PathVariable id: Int): ResponseEntity<ApiResult<String>> {
+        return ApiResponse.ok("GET > $id")
     }
 
     @PostMapping("/test")
@@ -55,7 +62,7 @@ class ApiExample {
     )
     @ApiResponses(
         value = [
-            ApiResponse(
+            io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
                 description = "요청 성공",
                 content = [Content(
@@ -65,8 +72,9 @@ class ApiExample {
             )
         ]
     )
-    fun postExample(@RequestBody request: DummyDto): ResponseEntity<String> {
-        return ResponseEntity.ok("POST > name: $request.name, age: $request.age")
-    }
+    fun postExample(@RequestBody request: DummyDto): ResponseEntity<ApiResult<DummyResDto>> {
+        val result = DummyResDto(request.name, request.age, "API Response")
 
+        return ApiResponse.created(result)
+    }
 }

--- a/src/main/kotlin/com/fesi/flowit/common/response/ApiResult.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/ApiResult.kt
@@ -1,0 +1,62 @@
+package com.fesi.flowit.common.response
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+
+/**
+ * Wraps ApiResult in a ResponseEntity, setting the HTTP status and response body
+ */
+fun <T> ApiResult<T>.toResponseEntity(): ResponseEntity<ApiResult<T>> {
+    return ResponseEntity.status(this.httpStatus).body(this)
+}
+
+/**
+ * Factory Method for creating ResponseEntity wrapping ApiResult
+ */
+object ApiResponse {
+    fun <T> ok(result: T): ResponseEntity<ApiResult<T>> = ApiResult.Success(result = result).toResponseEntity()
+    fun <T> created(result: T): ResponseEntity<ApiResult<T>> = ApiResult.Created(result = result).toResponseEntity()
+}
+
+/**
+ * API 응답 모델 정의
+ * 성공 예시)
+ *  HTTP/1.1 200 OK
+ *  {
+ *   "code" : "0000",
+ *   "message" : "OK",
+ *   "data" : { .. }
+ *  }
+ *
+ *  실패 예시)
+ *  HTTP/1.1 400 BAD REQUEST
+ *  {
+ *    "code" : "0400",
+ *    "message" : "Not found user",
+ *  }
+ */
+sealed class ApiResult<out T> (
+    open val code: String,
+    open val message: String,
+
+    @get:JsonIgnore
+    open val httpStatus: HttpStatus,
+) {
+    /**
+     * Related to success
+     */
+    data class Success<T>(
+        override val code: String = ApiResultCode.SUCCESS.code,
+        override val message: String = ApiResultCode.SUCCESS.message,
+        override val httpStatus: HttpStatus = HttpStatus.OK,
+        val result: T,
+    ) : ApiResult<T>(code, message, httpStatus)
+
+    data class Created<T>(
+        override val code: String = ApiResultCode.CREATED.code,
+        override val message: String = ApiResultCode.CREATED.message,
+        override val httpStatus: HttpStatus = HttpStatus.CREATED,
+        val result: T,
+    ) : ApiResult<T>(code, message, httpStatus)
+}

--- a/src/main/kotlin/com/fesi/flowit/common/response/ApiResult.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/ApiResult.kt
@@ -1,6 +1,7 @@
 package com.fesi.flowit.common.response
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fesi.flowit.common.response.exceptions.BaseException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 
@@ -58,5 +59,21 @@ sealed class ApiResult<out T> (
         override val message: String = ApiResultCode.CREATED.message,
         override val httpStatus: HttpStatus = HttpStatus.CREATED,
         val result: T,
+    ) : ApiResult<T>(code, message, httpStatus)
+
+
+    /**
+     * Related to failed
+     */
+    data class Error<T>(
+        override val code: String,
+        override val message: String,
+        override val httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR
+    ) : ApiResult<T>(code, message, httpStatus)
+
+    data class Exception<T : BaseException>(
+        override val code: String,
+        override val message: String,
+        override val httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR
     ) : ApiResult<T>(code, message, httpStatus)
 }

--- a/src/main/kotlin/com/fesi/flowit/common/response/ApiResultCode.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/ApiResultCode.kt
@@ -1,0 +1,17 @@
+package com.fesi.flowit.common.response
+
+/**
+ * API 응답 코드 정의
+ */
+
+enum class ApiResultCode(
+    val code: String,
+    val message: String
+) {
+    // 0-1000: Common Code
+    SUCCESS("0000", "OK"),
+    CREATED("0201", "Created"),
+
+    BAD_REQUEST("0400", "Bad Request"),
+    INTERNAL_ERROR("0500", "Unexpected Error");
+}

--- a/src/main/kotlin/com/fesi/flowit/common/response/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/GlobalExceptionHandler.kt
@@ -1,0 +1,34 @@
+package com.fesi.flowit.common.response
+
+import com.fesi.flowit.common.response.exceptions.BaseException
+import com.fesi.flowit.common.response.exceptions.ValidationException
+import com.fesi.flowit.common.response.exceptions.toApiResult
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import java.lang.Exception
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    @ExceptionHandler(BaseException::class)
+    fun handleValidation(ex: BaseException): ResponseEntity<ApiResult<Exception>> {
+        return when (ex) {
+            is ValidationException -> {
+                println("Validation is failed")
+                ex.toApiResult()
+            }
+            else -> ex.toApiResult()
+        }.toResponseEntity()
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleException(ex: Exception): ResponseEntity<ApiResult<Error>> {
+        return ApiResult.Error<Error>(
+            code = ApiResultCode.INTERNAL_ERROR.code,
+            message = ApiResultCode.INTERNAL_ERROR.message,
+            httpStatus = HttpStatus.INTERNAL_SERVER_ERROR
+        ).toResponseEntity()
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/common/response/exceptions/BaseException.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/exceptions/BaseException.kt
@@ -1,0 +1,17 @@
+package com.fesi.flowit.common.response.exceptions
+
+import com.fesi.flowit.common.response.ApiResult
+import com.fesi.flowit.common.response.ApiResultCode
+import org.springframework.http.HttpStatus
+
+fun BaseException.toApiResult() = ApiResult.Exception<BaseException>(
+    code = code.code,
+    message = code.message,
+    httpStatus = httpStatus
+)
+
+sealed class BaseException(
+    open val code: ApiResultCode,
+    open val httpStatus: HttpStatus,
+    override val message: String = code.message
+) : RuntimeException(message)

--- a/src/main/kotlin/com/fesi/flowit/common/response/exceptions/ValidationException.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/exceptions/ValidationException.kt
@@ -1,0 +1,9 @@
+package com.fesi.flowit.common.response.exceptions
+
+import com.fesi.flowit.common.response.ApiResultCode
+import org.springframework.http.HttpStatus
+
+class ValidationException(
+    override val code: ApiResultCode,
+    override val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST
+) : BaseException(code, httpStatus)


### PR DESCRIPTION
### Title
> 공통 API Response 구현

- API Response 공통 포맷
- 공통 예외 처리

### Description
#### API Response 공통 포맷
FE-BE 간 데이터를 주고 받는 형식을 통일시켜 효율적으로 데이터를 처리하는 것을 목표로 합니다.

요청 처리에 성공 시 다음과 같은 형식으로 데이터를 반환합니다.
```
{
 "code" : "0000",
 "message" : "OK",
 "data" : { 
     실제 API 응답 ...
  }
}
```
일반적으로 2XX 대 HTTP Status를 갖게 됩니다.

요청에 실패하는 경우 다음과 같은 형식으로 데이터를 반환합니다.

```
{
 "code" : "0400",
 "message" : "Bad Request",
}
```
성공과 달리 data가 없으며, 일반적으로 4XX 대 HTTP Status를 갖게 됩니다.
서버 측에서 처리하지 못하는 예외는 500 코드와 함께 반환됩니다.

#### 구현 및 활용법
모든 응답은 `ApiResultCode`에 정의됩니다. 이 내용들은 FE와 공유되어 상황에 맞게 후처리를 할 것으로 기대합니다.

정의된 응답 메시지는 `ApiResult`에 담겨져서 `ResponEntity`로 래핑되어 반환합니다.
ApiResult에는 HTTP Status가 포함되어 있지만, Json에는 포함되지 않도록 처리했습니다.
파일 상단에 ApiResponse라는 object ApiResponse라는 객체가 정의되어 있습니다. 
내부에는 Factory Method로 사용할 수 있도록 처리했으며, 컨트롤러에서 필요한 메소드를 가져다 사용하시면 됩니다.

### 예외 처리
일반 응답과 마찬가지로 비즈니스 로직 내에 처리되는 예외 처리는 `ApiResultCode`에 의해 정의되어 일관된 포맷으로 클라이언트에 반환됩니다.
일반적인 예외는 `BaseException`을 상속 받아 구현하시면 되고, 추적에 용이하도록 도메인별로 생성해서 사용하면 어떨까 싶습니다.

던져지는 예외는 `ExceptionHandler`에서 처리되며, 추가적인 처리가 필요한 경우 when 구문에 추가하거나, 각 클래스의 init block을 활용해주시면 됩니다.




