### PR TITLE
목표/생성 생성, 조회 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 	id("org.springframework.boot") version "3.5.3"
 	id("io.spring.dependency-management") version "1.1.7"
 	kotlin("plugin.jpa") version "1.9.25"
+	kotlin("kapt") version "1.9.21"
 }
 
 group = "com.fesi"
@@ -25,6 +26,11 @@ dependencies {
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
+	implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+
+	kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
+	kapt("jakarta.annotation:jakarta.annotation-api")
+	kapt("jakarta.persistence:jakarta.persistence-api")
 
 	runtimeOnly("org.postgresql:postgresql")
 
@@ -50,4 +56,22 @@ allOpen {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+}
+
+// QueryDSL QClass 생성 설정
+val querydslDir = "src/main/generated"
+sourceSets {
+	main {
+		kotlin.srcDirs += file(querydslDir)
+	}
+}
+
+tasks.named("clean") {
+	doLast {
+		file(querydslDir).deleteRecursively()
+	}
+}
+
+kapt {
+	generateStubs = true
 }

--- a/src/main/kotlin/com/fesi/flowit/common/config/QueryDSLConfig.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/config/QueryDSLConfig.kt
@@ -1,0 +1,15 @@
+package com.fesi.flowit.common.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QueryDSLConfig {
+
+    @Bean
+    fun jpaQueryFactory(entityManager: EntityManager): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/common/response/ApiResult.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/ApiResult.kt
@@ -2,6 +2,7 @@ package com.fesi.flowit.common.response
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fesi.flowit.common.response.exceptions.BaseException
+import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 
@@ -72,7 +73,16 @@ sealed class ApiResult<out T> (
     ) : ApiResult<T>(code, message, httpStatus)
 
     data class Exception<T : BaseException>(
+        @field:Schema(
+            description = "에러 코드",
+            example = "0400",
+        )
         override val code: String,
+
+        @field:Schema(
+            description = "에러 메시지",
+            example = "Bad Request",
+        )
         override val message: String,
         override val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST
     ) : ApiResult<T>(code, message, httpStatus)

--- a/src/main/kotlin/com/fesi/flowit/common/response/ApiResult.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/ApiResult.kt
@@ -74,6 +74,6 @@ sealed class ApiResult<out T> (
     data class Exception<T : BaseException>(
         override val code: String,
         override val message: String,
-        override val httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR
+        override val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST
     ) : ApiResult<T>(code, message, httpStatus)
 }

--- a/src/main/kotlin/com/fesi/flowit/common/response/ApiResultCode.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/ApiResultCode.kt
@@ -8,10 +8,17 @@ enum class ApiResultCode(
     val code: String,
     val message: String
 ) {
-    // 0-1000: Common Code
+    // 0-1000: General Code
     SUCCESS("0000", "OK"),
     CREATED("0201", "Created"),
-
     BAD_REQUEST("0400", "Bad Request"),
-    INTERNAL_ERROR("0500", "Unexpected Error");
+    INTERNAL_ERROR("0500", "Unexpected Error"),
+
+    // 2000-3000: Goal
+    GOAL_INVALID_DUE_DATETIME("3000", "Due date must be later than the creation time"),
+    GOAL_INVALID_NAME_LENGTH("3001", "Goal name must be 30 characters or less"),
+
+    // 9000-9999: Common Code
+    RGB_FORMAT_INVALID("9000", "Invalid RGB code format")
+    ;
 }

--- a/src/main/kotlin/com/fesi/flowit/common/response/ApiResultCode.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/ApiResultCode.kt
@@ -8,15 +8,20 @@ enum class ApiResultCode(
     val code: String,
     val message: String
 ) {
-    // 0-1000: General Code
+    // 0-999: General Code
     SUCCESS("0000", "OK"),
     CREATED("0201", "Created"),
     BAD_REQUEST("0400", "Bad Request"),
     INTERNAL_ERROR("0500", "Unexpected Error"),
 
-    // 2000-3000: Goal
+    // 2000-2999: Goal
     GOAL_INVALID_DUE_DATETIME("3000", "Due date must be later than the creation time"),
     GOAL_INVALID_NAME_LENGTH("3001", "Goal name must be 30 characters or less"),
+    GOAL_ID_INVALID("3002", "Goal-id is invalid."),
+
+    // 3000-3999: Todo
+    TODO_NOT_FOUND("4000", "Not found Todo"),
+    TODO_INVALID_GOAL("4001", "Goal with todo is invalid"),
 
     // 9000-9999: Common Code
     RGB_FORMAT_INVALID("9000", "Invalid RGB code format")

--- a/src/main/kotlin/com/fesi/flowit/common/response/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/GlobalExceptionHandler.kt
@@ -27,7 +27,7 @@ class GlobalExceptionHandler {
     fun handleException(ex: Exception): ResponseEntity<ApiResult<Error>> {
         return ApiResult.Error<Error>(
             code = ApiResultCode.INTERNAL_ERROR.code,
-            message = ApiResultCode.INTERNAL_ERROR.message,
+            message = ex.message ?: ApiResultCode.INTERNAL_ERROR.message,
             httpStatus = HttpStatus.INTERNAL_SERVER_ERROR
         ).toResponseEntity()
     }

--- a/src/main/kotlin/com/fesi/flowit/common/response/exceptions/GoalException.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/exceptions/GoalException.kt
@@ -1,0 +1,20 @@
+package com.fesi.flowit.common.response.exceptions
+
+import com.fesi.flowit.common.response.ApiResultCode
+import org.springframework.http.HttpStatus
+
+class GoalException(
+    override val code: ApiResultCode,
+    override val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST,
+    override val message: String
+) : BaseException(code, httpStatus) {
+    companion object {
+        fun fromCode(code: ApiResultCode): GoalException {
+            return GoalException(code = code, message = code.message)
+        }
+
+        fun fromCodeWithMsg(code: ApiResultCode, msg: String): GoalException {
+            return GoalException(code = code, message = msg)
+        }
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/common/response/exceptions/TodoException.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/exceptions/TodoException.kt
@@ -1,0 +1,20 @@
+package com.fesi.flowit.common.response.exceptions
+
+import com.fesi.flowit.common.response.ApiResultCode
+import org.springframework.http.HttpStatus
+
+class TodoException(
+    override val code: ApiResultCode,
+    override val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST,
+    override val message: String
+) : BaseException(code, httpStatus) {
+    companion object {
+        fun fromCode(code: ApiResultCode): TodoException {
+            return TodoException(code = code, message = code.message)
+        }
+
+        fun fromCodeWithMsg(code: ApiResultCode, msg: String): TodoException {
+            return TodoException(code = code, message = msg)
+        }
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/common/serializers/LocalDateTimeDeserializer.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/serializers/LocalDateTimeDeserializer.kt
@@ -1,0 +1,35 @@
+package com.fesi.flowit.common.serializers
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+/**
+ * 역직렬화 시 LocalDateTime Format으로 변환
+ */
+class LocalDateTimeDeserializer : JsonDeserializer<LocalDateTime>() {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): LocalDateTime {
+        val text = p.text
+
+        return try {
+            LocalDateTime.parse(text, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        } catch (e: DateTimeParseException) {
+            parseUsingLocalDate(text)
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Not supported data type")
+        }
+    }
+
+    private fun parseUsingLocalDate(text: String): LocalDateTime {
+        return try {
+            val date = LocalDate.parse(text, DateTimeFormatter.ISO_LOCAL_DATE)
+            return date.atStartOfDay()
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Not supported data type")
+        }
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/common/util/StringExtensions.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/util/StringExtensions.kt
@@ -1,0 +1,7 @@
+package com.fesi.flowit.common.util
+
+const val REGEX_RGB_CODE = "^#([A-Fa-f0-9]{6})\$"
+
+fun String.isRGBColor(): Boolean {
+    return this.matches(REGEX_RGB_CODE.toRegex())
+}

--- a/src/main/kotlin/com/fesi/flowit/goal/controller/GoalController.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/controller/GoalController.kt
@@ -1,0 +1,41 @@
+package com.fesi.flowit.goal.controller
+
+import com.fesi.flowit.common.response.ApiResult
+import com.fesi.flowit.goal.dto.GoalCreateRequestDto
+import com.fesi.flowit.goal.dto.GoalCreateResponseDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RequestBody
+
+interface GoalController {
+
+    @Operation(
+        summary = "목표 생성",
+        description = "목표 생성 모달로부터 목표를 생성합니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "목표 생성 성공",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = GoalCreateResponseDto::class)
+                )]
+            ),
+        ApiResponse(
+            responseCode = "400",
+            description = "올바르지 않은 요청 혹은 유효하지 않은 파라미터 값",
+            content = [Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ApiResult.Exception::class)
+            )]
+        )
+        ]
+    )
+    fun createGoal(@RequestBody request: GoalCreateRequestDto): ResponseEntity<ApiResult<GoalCreateResponseDto>>
+}

--- a/src/main/kotlin/com/fesi/flowit/goal/controller/GoalController.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/controller/GoalController.kt
@@ -3,6 +3,7 @@ package com.fesi.flowit.goal.controller
 import com.fesi.flowit.common.response.ApiResult
 import com.fesi.flowit.goal.dto.GoalCreateRequestDto
 import com.fesi.flowit.goal.dto.GoalCreateResponseDto
+import com.fesi.flowit.goal.dto.GoalFindAllResponseDto
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -38,4 +39,35 @@ interface GoalController {
         ]
     )
     fun createGoal(@RequestBody request: GoalCreateRequestDto): ResponseEntity<ApiResult<GoalCreateResponseDto>>
+
+    @Operation(
+        summary = "모든 목표 조회",
+        description =
+        """
+            모든 목표를 조회합니다. 리스트 순서는 다음 우선 순위에 따라 정렬됩니다.
+            1. 고정 여부
+            2. 생성 날짜
+        """
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "조회 성공",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = GoalFindAllResponseDto::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "올바르지 않은 요청 혹은 유효하지 않은 파라미터 값",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ApiResult.Exception::class)
+                )]
+            )
+        ]
+    )
+    fun findAllGoals(): ResponseEntity<ApiResult<List<GoalFindAllResponseDto>>>
 }

--- a/src/main/kotlin/com/fesi/flowit/goal/controller/GoalControllerImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/controller/GoalControllerImpl.kt
@@ -1,0 +1,31 @@
+package com.fesi.flowit.goal.controller
+
+import com.fesi.flowit.common.response.ApiResponse
+import com.fesi.flowit.common.response.ApiResult
+import com.fesi.flowit.goal.dto.GoalCreateRequestDto
+import com.fesi.flowit.goal.dto.GoalCreateResponseDto
+import com.fesi.flowit.goal.service.GoalService
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "목표")
+@RestController
+class GoalControllerImpl(
+    private val goalService: GoalService
+) : GoalController {
+
+    @PostMapping("/goal")
+    override fun createGoal(@RequestBody request: GoalCreateRequestDto): ResponseEntity<ApiResult<GoalCreateResponseDto>> {
+        val result = goalService.createGoal(
+            name = request.name,
+            color = request.color,
+            dueDateTime = request.dueDateTime
+        )
+
+        return ApiResponse.created(result)
+    }
+
+}

--- a/src/main/kotlin/com/fesi/flowit/goal/controller/GoalControllerImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/controller/GoalControllerImpl.kt
@@ -4,9 +4,11 @@ import com.fesi.flowit.common.response.ApiResponse
 import com.fesi.flowit.common.response.ApiResult
 import com.fesi.flowit.goal.dto.GoalCreateRequestDto
 import com.fesi.flowit.goal.dto.GoalCreateResponseDto
+import com.fesi.flowit.goal.dto.GoalFindAllResponseDto
 import com.fesi.flowit.goal.service.GoalService
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
@@ -28,4 +30,9 @@ class GoalControllerImpl(
         return ApiResponse.created(result)
     }
 
+    @GetMapping("/goals")
+    override fun findAllGoals(): ResponseEntity<ApiResult<List<GoalFindAllResponseDto>>> {
+        // @TODO user_id 필요
+        return ApiResponse.ok(goalService.findAllGoals())
+    }
 }

--- a/src/main/kotlin/com/fesi/flowit/goal/dto/GoalCreateRequestDto.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/dto/GoalCreateRequestDto.kt
@@ -1,0 +1,62 @@
+package com.fesi.flowit.goal.dto
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fesi.flowit.common.response.ApiResultCode
+import com.fesi.flowit.common.response.exceptions.GoalException
+import com.fesi.flowit.common.serializers.LocalDateTimeDeserializer
+import com.fesi.flowit.common.util.REGEX_RGB_CODE
+import com.fesi.flowit.common.util.isRGBColor
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class GoalCreateRequestDto(
+    @field:Schema(
+        description = "목표 이름",
+        example = "목표 이름",
+        minLength = 1,
+        maxLength = 30,
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    var name: String,
+
+    @field:Schema(
+        description = "목표 색상 코드",
+        example = "#000000",
+        pattern = REGEX_RGB_CODE,
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    val color: String,
+
+    @field:Schema(
+        description = "마감 기한",
+        example = "2025-07-19T14:29:00 | 2025-07-19",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @JsonDeserialize(using = LocalDateTimeDeserializer::class)
+    val dueDateTime: LocalDateTime,
+) {
+    init {
+        validateName()
+        validateColor()
+    }
+
+    private fun validateName() {
+        if (name.isBlank()) {
+            throw GoalException.fromCodeWithMsg(ApiResultCode.BAD_REQUEST, "Goal name is required.")
+        }
+
+        if (name.length !in 1..30) {
+            throw GoalException.fromCode(ApiResultCode.GOAL_INVALID_NAME_LENGTH)
+        }
+    }
+
+    private fun validateColor() {
+        if (isNonRGBColor(color)) {
+            throw GoalException.fromCode(ApiResultCode.RGB_FORMAT_INVALID)
+        }
+    }
+
+    private fun isNonRGBColor(color: String): Boolean {
+        return !color.isRGBColor()
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/goal/dto/GoalCreateResponseDto.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/dto/GoalCreateResponseDto.kt
@@ -1,0 +1,54 @@
+package com.fesi.flowit.goal.dto
+
+import com.fesi.flowit.common.util.REGEX_RGB_CODE
+import com.fesi.flowit.goal.entity.Goal
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class GoalCreateResponseDto(
+    @field:Schema(
+        description = "목표 이름",
+        example = "목표 이름",
+        minLength = 1,
+        maxLength = 30,
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    var name: String,
+
+    @field:Schema(
+        description = "목표 색상 코드",
+        example = "#000000",
+        pattern = REGEX_RGB_CODE,
+    )
+    val color: String,
+
+    @field:Schema(
+        description = "생성 시간",
+        example = "2025-07-19T14:29:00 | 2025-07-19",
+    )
+    val createdDateTime: LocalDateTime,
+
+    @field:Schema(
+        description = "마감 기한",
+        example = "2025-07-19T14:29:00 | 2025-07-19",
+    )
+    val dueDateTime: LocalDateTime,
+
+    @field:Schema(
+        description = "고정 여부",
+        example = "true | false",
+    )
+    val isPinned: Boolean
+) {
+    companion object {
+        fun fromGoal(goal: Goal): GoalCreateResponseDto {
+            return GoalCreateResponseDto(
+                name = goal.name,
+                color = goal.color,
+                createdDateTime = goal.createdDateTime,
+                dueDateTime = goal.dueDateTime,
+                isPinned = goal.isPinned
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/goal/dto/GoalFindAllResponseDto.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/dto/GoalFindAllResponseDto.kt
@@ -1,0 +1,30 @@
+package com.fesi.flowit.goal.dto
+
+import com.fesi.flowit.common.util.REGEX_RGB_CODE
+import com.querydsl.core.annotations.QueryProjection
+import io.swagger.v3.oas.annotations.media.Schema
+
+class GoalFindAllResponseDto @QueryProjection constructor(
+    @field:Schema(
+        description = "목표 이름",
+        example = "목표 이름",
+        minLength = 1,
+        maxLength = 30,
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    var name: String,
+
+    @field:Schema(
+        description = "목표 색상 코드",
+        example = "#000000",
+        pattern = REGEX_RGB_CODE,
+    )
+    var color: String,
+
+    @field:Schema(
+        description = "고정 여부",
+        example = "true | false",
+    )
+    var isPinned: Boolean
+) {
+}

--- a/src/main/kotlin/com/fesi/flowit/goal/entity/Goal.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/entity/Goal.kt
@@ -1,0 +1,51 @@
+package com.fesi.flowit.goal.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import java.time.LocalDateTime
+
+/**
+ * @todo 회원과 연관 관계 설정 필요
+ */
+
+@Entity
+@Table(name = "goal")
+class Goal private constructor(
+    @Column(nullable = false)
+    var name: String,
+
+    @Column(nullable = false)
+    var color: String = "#000000",
+
+    @Column(nullable = false)
+    val isPinned: Boolean = false,
+
+    @CreatedDate
+    @Column(nullable = false)
+    val createdDateTime: LocalDateTime = LocalDateTime.now(),
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    var modifiedDateTime: LocalDateTime = LocalDateTime.now(),
+
+    @Column(nullable = false)
+    val dueDateTime: LocalDateTime
+) {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+
+    companion object {
+        fun of(
+            name: String, color: String, isPinned: Boolean,
+            createdDateTime: LocalDateTime, modifiedDateTime: LocalDateTime, dueDateTime: LocalDateTime,
+        ): Goal {
+            return Goal(name, color, isPinned, createdDateTime, modifiedDateTime, dueDateTime)
+        }
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/goal/entity/Goal.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/entity/Goal.kt
@@ -1,10 +1,12 @@
 package com.fesi.flowit.goal.entity
 
+import com.fesi.flowit.todo.entity.Todo
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
@@ -35,10 +37,13 @@ class Goal private constructor(
     var modifiedDateTime: LocalDateTime = LocalDateTime.now(),
 
     @Column(nullable = false)
-    val dueDateTime: LocalDateTime
+    val dueDateTime: LocalDateTime,
 ) {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null
+
+    @OneToMany(mappedBy = "goal")
+    val todos: MutableList<Todo> = mutableListOf()
 
     companion object {
         fun of(
@@ -47,5 +52,9 @@ class Goal private constructor(
         ): Goal {
             return Goal(name, color, isPinned, createdDateTime, modifiedDateTime, dueDateTime)
         }
+    }
+
+    fun addTodo(todo: Todo) {
+        this.todos.add(todo)
     }
 }

--- a/src/main/kotlin/com/fesi/flowit/goal/repository/GoalQRepository.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/repository/GoalQRepository.kt
@@ -1,0 +1,7 @@
+package com.fesi.flowit.goal.repository
+
+import com.fesi.flowit.goal.dto.GoalFindAllResponseDto
+
+interface GoalQRepository {
+    fun findAllGoals(): List<GoalFindAllResponseDto>
+}

--- a/src/main/kotlin/com/fesi/flowit/goal/repository/GoalQRepositoryImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/repository/GoalQRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.fesi.flowit.goal.repository
+
+import com.fesi.flowit.goal.dto.GoalFindAllResponseDto
+import com.fesi.flowit.goal.dto.QGoalResponseDto
+import com.fesi.flowit.goal.entity.QGoal
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+
+@Repository
+class GoalQRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : GoalQRepository {
+    private val goal = QGoal.goal
+
+    override fun findAllGoals() : List<GoalFindAllResponseDto> {
+        return queryFactory
+            .select(QGoalResponseDto(goal.name, goal.color, goal.isPinned))
+            .from(goal)
+            .orderBy(goal.isPinned.desc())
+            .fetch()
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/goal/repository/GoalQRepositoryImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/repository/GoalQRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.fesi.flowit.goal.repository
 
 import com.fesi.flowit.goal.dto.GoalFindAllResponseDto
-import com.fesi.flowit.goal.dto.QGoalResponseDto
+import com.fesi.flowit.goal.dto.QGoalFindAllResponseDto
 import com.fesi.flowit.goal.entity.QGoal
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
@@ -14,7 +14,7 @@ class GoalQRepositoryImpl(
 
     override fun findAllGoals() : List<GoalFindAllResponseDto> {
         return queryFactory
-            .select(QGoalResponseDto(goal.name, goal.color, goal.isPinned))
+            .select(QGoalFindAllResponseDto(goal.name, goal.color, goal.isPinned))
             .from(goal)
             .orderBy(goal.isPinned.desc())
             .fetch()

--- a/src/main/kotlin/com/fesi/flowit/goal/repository/GoalRepository.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/repository/GoalRepository.kt
@@ -1,0 +1,6 @@
+package com.fesi.flowit.goal.repository
+
+import com.fesi.flowit.goal.entity.Goal
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GoalRepository : JpaRepository<Goal, Long>

--- a/src/main/kotlin/com/fesi/flowit/goal/service/GoalService.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/service/GoalService.kt
@@ -2,9 +2,11 @@ package com.fesi.flowit.goal.service
 
 import com.fesi.flowit.goal.dto.GoalCreateResponseDto
 import com.fesi.flowit.goal.dto.GoalFindAllResponseDto
+import com.fesi.flowit.goal.entity.Goal
 import java.time.LocalDateTime
 
 interface GoalService {
     fun createGoal(name: String, color: String, dueDateTime: LocalDateTime): GoalCreateResponseDto
     fun findAllGoals(): List<GoalFindAllResponseDto>
+    fun findGoalById(goalId: Long): Goal?
 }

--- a/src/main/kotlin/com/fesi/flowit/goal/service/GoalService.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/service/GoalService.kt
@@ -1,8 +1,10 @@
 package com.fesi.flowit.goal.service
 
 import com.fesi.flowit.goal.dto.GoalCreateResponseDto
+import com.fesi.flowit.goal.dto.GoalFindAllResponseDto
 import java.time.LocalDateTime
 
 interface GoalService {
     fun createGoal(name: String, color: String, dueDateTime: LocalDateTime): GoalCreateResponseDto
+    fun findAllGoals(): List<GoalFindAllResponseDto>
 }

--- a/src/main/kotlin/com/fesi/flowit/goal/service/GoalService.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/service/GoalService.kt
@@ -1,0 +1,8 @@
+package com.fesi.flowit.goal.service
+
+import com.fesi.flowit.goal.dto.GoalCreateResponseDto
+import java.time.LocalDateTime
+
+interface GoalService {
+    fun createGoal(name: String, color: String, dueDateTime: LocalDateTime): GoalCreateResponseDto
+}

--- a/src/main/kotlin/com/fesi/flowit/goal/service/GoalServiceImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/service/GoalServiceImpl.kt
@@ -1,0 +1,43 @@
+package com.fesi.flowit.goal.service
+
+import com.fesi.flowit.common.response.ApiResultCode
+import com.fesi.flowit.common.response.exceptions.GoalException
+import com.fesi.flowit.goal.dto.GoalCreateResponseDto
+import com.fesi.flowit.goal.entity.Goal
+import com.fesi.flowit.goal.repository.GoalRepository
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class GoalServiceImpl(
+    private val goalRepository: GoalRepository,
+) : GoalService {
+
+    /**
+     * 목표 생성
+     */
+    @Transactional
+    override fun createGoal(name: String, color: String, dueDateTime: LocalDateTime): GoalCreateResponseDto {
+        val createdDateTime: LocalDateTime = LocalDateTime.now()
+
+        if (isInvalidDueDateTime(dueDateTime, createdDateTime)) {
+            throw GoalException.fromCode(ApiResultCode.GOAL_INVALID_DUE_DATETIME)
+        }
+
+        val goal: Goal = goalRepository.save(Goal.of(
+            name = name,
+            color = color,
+            createdDateTime = createdDateTime,
+            modifiedDateTime = createdDateTime,
+            dueDateTime = dueDateTime,
+            isPinned = false
+        ))
+
+        return GoalCreateResponseDto.fromGoal(goal)
+    }
+
+    private fun isInvalidDueDateTime(dueDateTime: LocalDateTime, createDateTime: LocalDateTime): Boolean {
+        return dueDateTime.isBefore(createDateTime)
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/goal/service/GoalServiceImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/service/GoalServiceImpl.kt
@@ -3,7 +3,9 @@ package com.fesi.flowit.goal.service
 import com.fesi.flowit.common.response.ApiResultCode
 import com.fesi.flowit.common.response.exceptions.GoalException
 import com.fesi.flowit.goal.dto.GoalCreateResponseDto
+import com.fesi.flowit.goal.dto.GoalFindAllResponseDto
 import com.fesi.flowit.goal.entity.Goal
+import com.fesi.flowit.goal.repository.GoalQRepository
 import com.fesi.flowit.goal.repository.GoalRepository
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
@@ -12,6 +14,7 @@ import java.time.LocalDateTime
 @Service
 class GoalServiceImpl(
     private val goalRepository: GoalRepository,
+    private val goalQRepository: GoalQRepository
 ) : GoalService {
 
     /**
@@ -35,6 +38,13 @@ class GoalServiceImpl(
         ))
 
         return GoalCreateResponseDto.fromGoal(goal)
+    }
+
+    /**
+     * 모든 목표 조회
+     */
+    override fun findAllGoals(): List<GoalFindAllResponseDto> {
+        return goalQRepository.findAllGoals()
     }
 
     private fun isInvalidDueDateTime(dueDateTime: LocalDateTime, createDateTime: LocalDateTime): Boolean {

--- a/src/main/kotlin/com/fesi/flowit/goal/service/GoalServiceImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/service/GoalServiceImpl.kt
@@ -47,6 +47,10 @@ class GoalServiceImpl(
         return goalQRepository.findAllGoals()
     }
 
+    override fun findGoalById(goalId: Long): Goal? {
+        return goalRepository.findById(goalId).orElse(null)
+    }
+
     private fun isInvalidDueDateTime(dueDateTime: LocalDateTime, createDateTime: LocalDateTime): Boolean {
         return dueDateTime.isBefore(createDateTime)
     }

--- a/src/main/kotlin/com/fesi/flowit/todo/controller/TodoController.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/controller/TodoController.kt
@@ -1,0 +1,41 @@
+package com.fesi.flowit.todo.controller
+
+import com.fesi.flowit.common.response.ApiResult
+import com.fesi.flowit.goal.dto.GoalCreateResponseDto
+import com.fesi.flowit.todo.dto.TodoCreateRequestDto
+import com.fesi.flowit.todo.dto.TodoCreateResponseDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RequestBody
+
+interface TodoController {
+    @Operation(
+        summary = "할 일 생성",
+        description = "목표에 할 일을 생성합니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "할 일 생성 성공",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = GoalCreateResponseDto::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "올바르지 않은 요청 혹은 유효하지 않은 파라미터 값",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ApiResult.Exception::class)
+                )]
+            )
+        ]
+    )
+    fun createTodo(@RequestBody request: TodoCreateRequestDto): ResponseEntity<ApiResult<TodoCreateResponseDto>>
+}

--- a/src/main/kotlin/com/fesi/flowit/todo/controller/TodoControllerImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/controller/TodoControllerImpl.kt
@@ -1,0 +1,24 @@
+package com.fesi.flowit.todo.controller
+
+import com.fesi.flowit.common.response.ApiResponse
+import com.fesi.flowit.common.response.ApiResult
+import com.fesi.flowit.todo.dto.TodoCreateRequestDto
+import com.fesi.flowit.todo.dto.TodoCreateResponseDto
+import com.fesi.flowit.todo.service.TodoService
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "할 일")
+@RestController
+class TodoControllerImpl(
+    private val todoService: TodoService
+) : TodoController {
+
+    @PostMapping("/todo")
+    override fun createTodo(@RequestBody request: TodoCreateRequestDto): ResponseEntity<ApiResult<TodoCreateResponseDto>> {
+        return ApiResponse.created(todoService.createTodo(request.name, request.goalId))
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/todo/dto/TodoCreateRequestDto.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/dto/TodoCreateRequestDto.kt
@@ -1,0 +1,44 @@
+package com.fesi.flowit.todo.dto
+
+import com.fesi.flowit.common.response.ApiResultCode
+import com.fesi.flowit.common.response.exceptions.TodoException
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class TodoCreateRequestDto(
+    @field:Schema(
+        description = "할 일 이름",
+        example = "할 일",
+        minLength = 1,
+        maxLength = 30,
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    val name: String,
+
+    @field:Schema(
+        description = "목표 ID",
+        example = "10",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    val goalId: Long
+) {
+    init {
+        validateName()
+        validateGoalId()
+    }
+
+    private fun validateName() {
+        if (name.isBlank()) {
+            throw TodoException.fromCodeWithMsg(ApiResultCode.BAD_REQUEST, "Goal name is required.")
+        }
+
+        if (name.length !in 1..30) {
+            throw TodoException.fromCode(ApiResultCode.GOAL_INVALID_NAME_LENGTH)
+        }
+    }
+
+    private fun validateGoalId() {
+        if (goalId < 0) {
+            throw TodoException.fromCode(ApiResultCode.GOAL_ID_INVALID)
+        }
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/todo/dto/TodoCreateResponseDto.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/dto/TodoCreateResponseDto.kt
@@ -1,0 +1,33 @@
+package com.fesi.flowit.todo.dto
+
+import com.fesi.flowit.common.response.ApiResultCode
+import com.fesi.flowit.common.response.exceptions.TodoException
+import com.fesi.flowit.todo.entity.Todo
+import io.swagger.v3.oas.annotations.media.Schema
+
+class TodoCreateResponseDto(
+    @field:Schema(
+        description = "할 일 이름",
+        example = "할 일",
+        minLength = 1,
+        maxLength = 30,
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    val name: String,
+
+    @field:Schema(
+        description = "목표 ID",
+        example = "10",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    val goalId: Long
+) {
+
+    companion object {
+        fun fromTodo(todo: Todo): TodoCreateResponseDto {
+            return TodoCreateResponseDto(
+                name = todo.name,
+                goalId = todo.goal?.id ?: throw TodoException.fromCodeWithMsg(ApiResultCode.TODO_INVALID_GOAL, "goal-id is null"))
+        }
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/todo/entity/Todo.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/entity/Todo.kt
@@ -1,0 +1,48 @@
+package com.fesi.flowit.todo.entity
+
+import com.fesi.flowit.goal.entity.Goal
+import jakarta.persistence.*
+import org.springframework.data.annotation.CreatedDate
+import java.time.LocalDateTime
+
+@Entity
+@Table(name ="todo")
+class Todo private constructor(
+    @Column(nullable = false)
+    val name: String,
+
+    @Column(nullable = false)
+    val isDone: Boolean = false,
+
+    @CreatedDate
+    @Column(nullable = false)
+    val createdDateTime: LocalDateTime,
+
+    @Column(nullable = false)
+    var modifiedDateTime: LocalDateTime,
+
+    @Column
+    var doneDateTime: LocalDateTime? = null
+) {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST])
+    @JoinColumn(name = "goal_id")
+    var goal: Goal? = null
+        set(goal) {
+            field = goal
+            goal?.addTodo(this)
+        }
+    companion object {
+        fun of(name: String, isDone: Boolean, createdDateTime: LocalDateTime, modifiedDateTime: LocalDateTime): Todo {
+            return Todo(name, isDone, createdDateTime, modifiedDateTime, null)
+        }
+
+        fun withGoal(name: String, isDone: Boolean, createdDateTime: LocalDateTime, modifiedDateTime: LocalDateTime, goal: Goal): Todo {
+            val todo = of(name, isDone, createdDateTime, modifiedDateTime)
+            todo.goal = goal
+            return todo
+        }
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/todo/repository/TodoRepository.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/repository/TodoRepository.kt
@@ -1,0 +1,6 @@
+package com.fesi.flowit.todo.repository
+
+import com.fesi.flowit.todo.entity.Todo
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TodoRepository : JpaRepository<Todo, Long>

--- a/src/main/kotlin/com/fesi/flowit/todo/service/TodoService.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/service/TodoService.kt
@@ -1,0 +1,7 @@
+package com.fesi.flowit.todo.service
+
+import com.fesi.flowit.todo.dto.TodoCreateResponseDto
+
+interface TodoService {
+    fun createTodo(name: String, goalId: Long): TodoCreateResponseDto
+}

--- a/src/main/kotlin/com/fesi/flowit/todo/service/TodoServiceImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/service/TodoServiceImpl.kt
@@ -1,0 +1,37 @@
+package com.fesi.flowit.todo.service
+
+import com.fesi.flowit.common.response.ApiResultCode
+import com.fesi.flowit.common.response.exceptions.TodoException
+import com.fesi.flowit.goal.service.GoalService
+import com.fesi.flowit.todo.dto.TodoCreateResponseDto
+import com.fesi.flowit.todo.entity.Todo
+import com.fesi.flowit.todo.repository.TodoRepository
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class TodoServiceImpl(
+    private val goalService: GoalService,
+    private val todoRepository: TodoRepository
+) : TodoService {
+
+    /**
+     * 할 일 생성
+     */
+    @Transactional
+    override fun createTodo(name: String, goalId: Long): TodoCreateResponseDto {
+        val createdDateTime = LocalDateTime.now()
+        val goal = goalService.findGoalById(goalId) ?: throw TodoException.fromCode(ApiResultCode.TODO_NOT_FOUND)
+
+        val todo = todoRepository.save(Todo.withGoal(
+            name = name,
+            isDone = false,
+            createdDateTime = createdDateTime,
+            modifiedDateTime = createdDateTime,
+            goal = goal
+        ))
+
+        return TodoCreateResponseDto.fromTodo(todo)
+    }
+}


### PR DESCRIPTION
[ #4 ]
목표/생성 구현을 위한 엔티티 기본 설계 및 생성, 조회 API를 구현하였습니다.
회원 관련된 필드는 머지 후에 추가 작업 예정이며, 대시보드 API는 dashboard 브랜치에서 작업 예정입니다.

참고로, API 요건 상 동적 쿼리가 많을 듯 하여 QueryDSL을 사용하게 되었습니다.
상황에 맞게 Spring Data JPA와 함께 활용하면 좋을 것 같습니다.