### PR TITLE
FEAT, CHORE:일정 관련 구현 및 CORS 설정

### DIFF
--- a/src/main/kotlin/com/fesi/flowit/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/config/SecurityConfig.kt
@@ -10,6 +10,9 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.access.intercept.AuthorizationFilter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 
 @Configuration
@@ -21,6 +24,7 @@ class SecurityConfig(
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         val filterChain = http
             .csrf { it.disable() }
+            .cors { it.configurationSource(corsConfigurationSource()) }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests {
                 it
@@ -39,6 +43,19 @@ class SecurityConfig(
             .build()
 
         return filterChain
+    }
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration()
+        configuration.allowedOrigins = listOf("*")
+        configuration.allowedMethods = listOf("*")
+        configuration.allowedHeaders = listOf("*")
+        configuration.allowCredentials = false
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+        return source
     }
 
     @Bean

--- a/src/main/kotlin/com/fesi/flowit/common/response/ApiResultCode.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/ApiResultCode.kt
@@ -33,6 +33,11 @@ enum class ApiResultCode(
     TODO_INVALID_GOAL("4002", "Goal with todo is invalid"),
     TODO_NOT_MATCH_USER("4003", "The user has not this todo"),
 
+    // 5000-5999: Schedule
+    SCHED_NOT_FOUND("5000", "Not found schedule"),
+    SCHED_INVALID_ID("5001", "Schedule-id is invalid"),
+    SCHED_INVALID_TODO("5002", "Invalid todo in schedule"),
+
     // 9000-9999: Common Code
     RGB_FORMAT_INVALID("9000", "Invalid RGB code format"),
 

--- a/src/main/kotlin/com/fesi/flowit/common/response/exceptions/ScheduleException.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/exceptions/ScheduleException.kt
@@ -1,0 +1,20 @@
+package com.fesi.flowit.common.response.exceptions
+
+import com.fesi.flowit.common.response.ApiResultCode
+import org.springframework.http.HttpStatus
+
+class ScheduleException(
+    override val code: ApiResultCode,
+    override val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST,
+    override val message: String
+) : BaseException(code, httpStatus) {
+    companion object {
+        fun fromCode(code: ApiResultCode): ScheduleException {
+            return ScheduleException(code = code, message = code.message)
+        }
+
+        fun fromCodeWithMsg(code: ApiResultCode, msg: String): ScheduleException {
+            return ScheduleException(code = code, message = msg)
+        }
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/schedule/Schedule.kt
+++ b/src/main/kotlin/com/fesi/flowit/schedule/Schedule.kt
@@ -1,8 +1,0 @@
-package com.fesi.flowit.schedule
-
-class Schedule {
-    override fun equals(other: Any?): Boolean {
-        return super.equals(other)
-    }
-    // 일정은 목표를 시간에 할당해놓는 것. 아예 따로 엔티티로 들자..
-}

--- a/src/main/kotlin/com/fesi/flowit/schedule/controller/SchedController.kt
+++ b/src/main/kotlin/com/fesi/flowit/schedule/controller/SchedController.kt
@@ -1,0 +1,11 @@
+package com.fesi.flowit.schedule.controller
+
+import com.fesi.flowit.common.response.ApiResult
+import com.fesi.flowit.schedule.dto.SchedCreateRequestDto
+import com.fesi.flowit.schedule.dto.SchedCreateResponseDto
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RequestBody
+
+interface SchedController {
+    fun createSchedules(@RequestBody request: SchedCreateRequestDto): ResponseEntity<ApiResult<SchedCreateResponseDto>>
+}

--- a/src/main/kotlin/com/fesi/flowit/schedule/controller/SchedControllerImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/schedule/controller/SchedControllerImpl.kt
@@ -1,0 +1,27 @@
+package com.fesi.flowit.schedule.controller
+
+import com.fesi.flowit.common.logging.loggerFor
+import com.fesi.flowit.common.response.ApiResponse
+import com.fesi.flowit.common.response.ApiResult
+import com.fesi.flowit.schedule.dto.SchedCreateRequestDto
+import com.fesi.flowit.schedule.dto.SchedCreateResponseDto
+import com.fesi.flowit.schedule.service.SchedService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+private val log = loggerFor<SchedControllerImpl>()
+
+@RestController
+class SchedControllerImpl(
+    private val schedService: SchedService
+) : SchedController {
+
+    @PostMapping("/schedules")
+    override fun createSchedules(@RequestBody request: SchedCreateRequestDto): ResponseEntity<ApiResult<SchedCreateResponseDto>> {
+        log.debug(">> request createSchedules(${request})")
+
+        return ApiResponse.created(schedService.createSchedules(request))
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/schedule/dto/SchedCreateRequestDto.kt
+++ b/src/main/kotlin/com/fesi/flowit/schedule/dto/SchedCreateRequestDto.kt
@@ -1,0 +1,14 @@
+package com.fesi.flowit.schedule.dto
+
+import java.time.LocalDateTime
+
+data class SchedCreateRequestDto(
+    var userId: Long,
+    var scheduleInfos: MutableList<SchedTodoAndDateInfo>
+)
+
+data class SchedTodoAndDateInfo(
+    var todoId: Long,
+    var startedDateTime: LocalDateTime,
+    var endedDateTime: LocalDateTime,
+)

--- a/src/main/kotlin/com/fesi/flowit/schedule/dto/SchedCreateResponseDto.kt
+++ b/src/main/kotlin/com/fesi/flowit/schedule/dto/SchedCreateResponseDto.kt
@@ -1,0 +1,28 @@
+package com.fesi.flowit.schedule.dto
+
+import com.fesi.flowit.common.response.ApiResultCode
+import com.fesi.flowit.common.response.exceptions.ScheduleException
+import com.fesi.flowit.schedule.entity.Schedule
+
+data class SchedCreateResponseDto(
+    val userId:Long,
+    val schedules: MutableList<SchedSummaryResponseDto>
+) {
+    companion object {
+
+        fun fromSchedules(userId: Long, schedules: List<Schedule>): SchedCreateResponseDto {
+            val summaries = schedules.map { sched ->
+                SchedSummaryResponseDto(
+                    scheduleId = sched.id ?: throw ScheduleException.fromCode(ApiResultCode.SCHED_INVALID_ID),
+                    todoId = sched.todo.id ?: throw ScheduleException.fromCode(ApiResultCode.SCHED_INVALID_TODO),
+                    todoName = sched.todo.name,
+                    color = sched.todo.goal?.color ?: "#000000",
+                    startedDateTime = sched.startedDateTime,
+                    endedDateTime = sched.endedDateTime
+                )
+            }.toMutableList()
+
+            return SchedCreateResponseDto(userId, summaries)
+        }
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/schedule/dto/SchedSummaryResponseDto.kt
+++ b/src/main/kotlin/com/fesi/flowit/schedule/dto/SchedSummaryResponseDto.kt
@@ -1,0 +1,12 @@
+package com.fesi.flowit.schedule.dto
+
+import java.time.LocalDateTime
+
+data class SchedSummaryResponseDto(
+    var scheduleId: Long,
+    var todoId: Long,
+    var todoName: String,
+    var color: String,
+    var startedDateTime: LocalDateTime,
+    var endedDateTime: LocalDateTime
+)

--- a/src/main/kotlin/com/fesi/flowit/schedule/entity/Schedule.kt
+++ b/src/main/kotlin/com/fesi/flowit/schedule/entity/Schedule.kt
@@ -1,0 +1,37 @@
+package com.fesi.flowit.schedule.entity
+
+import com.fesi.flowit.todo.entity.Todo
+import com.fesi.flowit.user.entity.User
+import jakarta.persistence.*
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "schedules")
+class Schedule private constructor(
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    var user: User,
+
+    @ManyToOne
+    @JoinColumn(name = "todo_id")
+    var todo: Todo,
+
+    @Column(nullable = false)
+    var startedDateTime: LocalDateTime,
+
+    @Column(nullable = false)
+    var endedDateTime: LocalDateTime,
+
+    @CreatedDate
+    @Column(nullable = false)
+    var createdDateTime: LocalDateTime = LocalDateTime.now(),
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    var modifiedDateTime: LocalDateTime = LocalDateTime.now()
+) {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+}

--- a/src/main/kotlin/com/fesi/flowit/schedule/entity/Schedule.kt
+++ b/src/main/kotlin/com/fesi/flowit/schedule/entity/Schedule.kt
@@ -34,4 +34,11 @@ class Schedule private constructor(
 ) {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null
+
+    companion object {
+        fun of(user: User, todo: Todo,
+               startedDateTime: LocalDateTime, endedDateTime: LocalDateTime, createdDateTime: LocalDateTime): Schedule {
+            return Schedule(user, todo, startedDateTime, endedDateTime, createdDateTime, modifiedDateTime = createdDateTime)
+        }
+    }
 }

--- a/src/main/kotlin/com/fesi/flowit/schedule/repository/ScheduleRepository.kt
+++ b/src/main/kotlin/com/fesi/flowit/schedule/repository/ScheduleRepository.kt
@@ -1,0 +1,8 @@
+package com.fesi.flowit.schedule.repository
+
+import com.fesi.flowit.schedule.entity.Schedule
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ScheduleRepository : JpaRepository<Schedule, Long>

--- a/src/main/kotlin/com/fesi/flowit/schedule/service/SchedService.kt
+++ b/src/main/kotlin/com/fesi/flowit/schedule/service/SchedService.kt
@@ -1,0 +1,8 @@
+package com.fesi.flowit.schedule.service
+
+import com.fesi.flowit.schedule.dto.SchedCreateRequestDto
+import com.fesi.flowit.schedule.dto.SchedCreateResponseDto
+
+interface SchedService {
+    fun createSchedules(request: SchedCreateRequestDto): SchedCreateResponseDto
+}

--- a/src/main/kotlin/com/fesi/flowit/schedule/service/SchedServiceImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/schedule/service/SchedServiceImpl.kt
@@ -1,0 +1,55 @@
+package com.fesi.flowit.schedule.service
+
+import com.fesi.flowit.common.response.ApiResultCode
+import com.fesi.flowit.common.response.exceptions.ScheduleException
+import com.fesi.flowit.common.response.exceptions.TodoException
+import com.fesi.flowit.schedule.dto.SchedCreateRequestDto
+import com.fesi.flowit.schedule.dto.SchedCreateResponseDto
+import com.fesi.flowit.schedule.entity.Schedule
+import com.fesi.flowit.schedule.repository.ScheduleRepository
+import com.fesi.flowit.todo.entity.Todo
+import com.fesi.flowit.todo.service.TodoService
+import com.fesi.flowit.user.entity.User
+import com.fesi.flowit.user.service.UserService
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class SchedServiceImpl(
+    private val userService: UserService,
+    private val todoService: TodoService,
+    private val scheduleRepository: ScheduleRepository
+) : SchedService {
+
+    @Transactional
+    override fun createSchedules(request: SchedCreateRequestDto): SchedCreateResponseDto {
+        val user: User = userService.findUserById(request.userId)
+
+        val todoMap: Map<Long, Todo> = todoService
+            .getTodosByIds(request.scheduleInfos.map { it.todoId })
+            .associateBy { it.id ?: throw TodoException.fromCode(ApiResultCode.TODO_INVALID_ID) }
+
+        val createdDateTime = LocalDateTime.now()
+
+        val schedules: List<Schedule> = request.scheduleInfos.map {sched ->
+            val todo = todoMap[sched.todoId] ?: throw ScheduleException.fromCode(ApiResultCode.SCHED_INVALID_TODO)
+
+            if (todo.doesNotUserOwnTodo(user)) {
+                throw ScheduleException.fromCode(ApiResultCode.TODO_NOT_MATCH_USER)
+            }
+
+            Schedule.of(
+                user = user,
+                todo = todo,
+                startedDateTime = sched.startedDateTime,
+                endedDateTime = sched.endedDateTime,
+                createdDateTime = createdDateTime
+            )
+        }
+
+        val savedSchedules: List<Schedule> = scheduleRepository.saveAll(schedules)
+
+        return SchedCreateResponseDto.fromSchedules(user.id, savedSchedules)
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/todo/entity/Todo.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/entity/Todo.kt
@@ -1,6 +1,7 @@
 package com.fesi.flowit.todo.entity
 
 import com.fesi.flowit.goal.entity.Goal
+import com.fesi.flowit.schedule.entity.Schedule
 import com.fesi.flowit.user.entity.User
 import jakarta.persistence.*
 import org.springframework.data.annotation.CreatedDate
@@ -39,6 +40,9 @@ class Todo private constructor(
             field = goal
             goal?.addTodo(this)
         }
+
+    @OneToMany(mappedBy = "todo", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val schedules: MutableList<Schedule> = mutableListOf()
 
     companion object {
         fun of(user: User, name: String, isDone: Boolean, createdDateTime: LocalDateTime, modifiedDateTime: LocalDateTime): Todo {

--- a/src/main/kotlin/com/fesi/flowit/todo/entity/Todo.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/entity/Todo.kt
@@ -55,4 +55,8 @@ class Todo private constructor(
             return todo
         }
     }
+
+    fun doesNotUserOwnTodo(user: User): Boolean {
+        return this.user != user
+    }
 }

--- a/src/main/kotlin/com/fesi/flowit/todo/service/TodoService.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/service/TodoService.kt
@@ -2,9 +2,11 @@ package com.fesi.flowit.todo.service
 
 import com.fesi.flowit.todo.dto.TodoCreateResponseDto
 import com.fesi.flowit.todo.dto.TodoModifyResponseDto
+import com.fesi.flowit.todo.entity.Todo
 
 interface TodoService {
     fun createTodo(userId: Long, name: String, goalId: Long): TodoCreateResponseDto
     fun modifyTodo(todoId: Long, userId: Long, name: String, goalId: Long): TodoModifyResponseDto
     fun deleteTodoById(userId: Long, todoId: Long)
+    fun getTodosByIds(todoIds: List<Long>): List<Todo>
 }

--- a/src/main/kotlin/com/fesi/flowit/todo/service/TodoServiceImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/service/TodoServiceImpl.kt
@@ -53,7 +53,7 @@ class TodoServiceImpl(
         val user: User = userService.findUserById(userId)
         val todo: Todo = getTodoById(todoId)
 
-        if (doesNotUserOwnTodo(user, todo)) {
+        if (todo.doesNotUserOwnTodo(user)) {
             throw TodoException.fromCode(ApiResultCode.TODO_NOT_MATCH_USER)
         }
 
@@ -83,7 +83,7 @@ class TodoServiceImpl(
         val user: User = userService.findUserById(userId)
         val todo: Todo = getTodoById(todoId)
 
-        if (doesNotUserOwnTodo(user, todo)) {
+        if (todo.doesNotUserOwnTodo(user)) {
             throw TodoException.fromCode(ApiResultCode.TODO_NOT_MATCH_USER)
         }
 
@@ -91,8 +91,8 @@ class TodoServiceImpl(
         log.debug("Deleted todo(id=${todo.id}, name=${todo.name}, isDone=${todo.isDone}")
     }
 
-    private fun doesNotUserOwnTodo(user: User, todo: Todo): Boolean {
-        return todo.user != user
+    override fun getTodosByIds(todoIds: List<Long>): List<Todo> {
+        return todoRepository.findAllById(todoIds)
     }
 
     private fun getTodoById(todoId: Long): Todo {

--- a/src/main/kotlin/com/fesi/flowit/user/entity/User.kt
+++ b/src/main/kotlin/com/fesi/flowit/user/entity/User.kt
@@ -1,6 +1,7 @@
 package com.fesi.flowit.user.entity
 
 import com.fesi.flowit.goal.entity.Goal
+import com.fesi.flowit.schedule.entity.Schedule
 import com.fesi.flowit.todo.entity.Todo
 import jakarta.persistence.*
 import java.time.LocalDateTime
@@ -39,6 +40,9 @@ class User(
 
     @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL])
     val todos: MutableList<Todo> = mutableListOf()
+
+    @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL])
+    val schedules: MutableList<Schedule> = mutableListOf()
 
     companion object {
         fun of(


### PR DESCRIPTION
MVP1 대응을 하다 보니 한 브랜치 내에서 두 개의 작업을 진행하게 되었습니다.

### 일정
브랜치 내 미완성 코드가 반영되어 있어서 일정 생성 API까지 먼저 PR을 요청합니다.
- 일정 엔티티 설계 (회원-일정 1:N, 할 일-일정 1:N 관계 설정)
- 일정 생성 API 구현 (Bulk Insert)

### CORS
급한대로 모든 요청을 허용하도록 설정을 하였습니다. VPC 내에서 일정한 IP로 요청이 오기 때문에 제한을 걸어도 좋고, 도메인이 생기면 제한을 걸어도 좋을 것 같아요.  Security 쪽 담당해주신 만큼 CORS도 이어서 진행 부탁드립니다.