### PR TITLE
FEAT: 모든 목표 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/fesi/flowit/common/response/PageResponse.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/PageResponse.kt
@@ -1,0 +1,45 @@
+package com.fesi.flowit.common.response
+
+import org.springframework.data.domain.Page
+
+data class PageResponse<T>(
+    val contents: List<T>,
+    val page: Int,
+    val size: Int,
+    val totalPage: Int,
+    val totalElement: Long,
+    val isFirst: Boolean,
+    val isLast: Boolean,
+    val hasNext: Boolean,
+    val hasPrev: Boolean
+) {
+    companion object {
+        fun <T> fromPage(page: Page<T>): PageResponse<T> {
+            return PageResponse(
+                contents = page.content,
+                page = page.number + 1,
+                size = page.size,
+                totalPage = page.totalPages,
+                totalElement = page.totalElements,
+                isFirst = page.isFirst,
+                isLast = page.isLast,
+                hasNext = page.hasNext(),
+                hasPrev = page.hasPrevious()
+            )
+        }
+
+        fun <T, E> fromPageWithContents(contents: List<T>, page: Page<E>): PageResponse<T> {
+            return PageResponse(
+                contents = contents,
+                page = page.number + 1,
+                size = page.size,
+                totalPage = page.totalPages,
+                totalElement = page.totalElements,
+                isFirst = page.isFirst,
+                isLast = page.isLast,
+                hasNext = page.hasNext(),
+                hasPrev = page.hasPrevious()
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/goal/controller/GoalController.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/controller/GoalController.kt
@@ -1,12 +1,15 @@
 package com.fesi.flowit.goal.controller
 
 import com.fesi.flowit.common.response.ApiResult
+import com.fesi.flowit.common.response.PageResponse
 import com.fesi.flowit.goal.dto.*
+import com.fesi.flowit.goal.search.GoalSortCriteria
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.data.domain.Pageable
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
@@ -126,8 +129,8 @@ interface GoalController {
     fun getAllGoals(@RequestParam("userId") userId: Long): ResponseEntity<ApiResult<List<GoalFindAllResponseDto>>>
 
     @Operation(
-        summary = "목표 별 할 일",
-        description = "목표와 관련된 정보를 반환합니다."
+        summary = "모든 목표 조회",
+        description = "모든 목표를 조건에 따라 탐색합니다."
     )
     @ApiResponses(
         value = [
@@ -149,7 +152,38 @@ interface GoalController {
             )
         ]
     )
-    fun getGoalsSummary(@RequestParam("userId") userId: Long): ResponseEntity<ApiResult<List<GoalSummaryResponseDto>>>
+    fun searchGoalSummaries(
+        @RequestParam("userId") userId: Long,
+        @RequestParam("isPinned") isPinned: Boolean,
+        @RequestParam("sortedBy") sortedBy: GoalSortCriteria,
+        pageable: Pageable
+    ): ResponseEntity<ApiResult<PageResponse<GoalSummaryResponseDto>>>
+
+    @Operation(
+        summary = "목표 별 할 일",
+        description = "목표와 관련된 정보를 반환합니다. 대시보드 > 목표 별 할 일"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "조회 성공",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = GoalSummaryResponseDto::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "올바르지 않은 요청 혹은 유효하지 않은 파라미터 값",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ApiResult.Exception::class)
+                )]
+            )
+        ]
+    )
+    fun getGoalsInDashboard(@RequestParam("userId") userId: Long): ResponseEntity<ApiResult<List<GoalSummaryResponseDto>>>
 
     @Operation(
         summary = "월 별 목표 조회 (캘린더)",

--- a/src/main/kotlin/com/fesi/flowit/goal/controller/GoalControllerImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/controller/GoalControllerImpl.kt
@@ -3,9 +3,13 @@ package com.fesi.flowit.goal.controller
 import com.fesi.flowit.common.logging.loggerFor
 import com.fesi.flowit.common.response.ApiResponse
 import com.fesi.flowit.common.response.ApiResult
+import com.fesi.flowit.common.response.PageResponse
 import com.fesi.flowit.goal.dto.*
+import com.fesi.flowit.goal.search.GoalSortCriteria
 import com.fesi.flowit.goal.service.GoalService
+import com.fesi.flowit.goal.search.GoalWidgetCondition
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Pageable
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -73,10 +77,23 @@ class GoalControllerImpl(
         return ApiResponse.ok(goalService.getAllGoals(userId))
     }
 
+    @GetMapping("/goals/dashboard")
+    override fun getGoalsInDashboard(@RequestParam("userId") userId: Long): ResponseEntity<ApiResult<List<GoalSummaryResponseDto>>> {
+        log.debug(">> request getGoalsInDashboard(userId=${userId}")
+        return ApiResponse.ok(goalService.getGoalsSummariesInDashboard(userId))
+    }
+
     @GetMapping("/goals/todos")
-    override fun getGoalsSummary(@RequestParam("userId") userId: Long): ResponseEntity<ApiResult<List<GoalSummaryResponseDto>>> {
-        log.debug(">> request getGoalsSummary(userId=${userId}")
-        return ApiResponse.ok(goalService.getGoalsSummaries(userId))
+    override fun searchGoalSummaries(
+        @RequestParam("userId") userId: Long,
+        @RequestParam("isPinned") isPinned: Boolean,
+        @RequestParam("sortedBy") sortedBy: GoalSortCriteria,
+        pageable: Pageable
+    ): ResponseEntity<ApiResult<PageResponse<GoalSummaryResponseDto>>> {
+        log.debug(">> request searchGoalSummaries(userId=${userId}, isPinned=${isPinned}, sortedBy=${sortedBy} page=${pageable}}")
+
+        val searchCond = GoalWidgetCondition(userId, sortedBy, isPinned)
+        return ApiResponse.ok(goalService.searchGoalSummaries(searchCond, pageable))
     }
 
     @GetMapping("/goals/todos/due-monthly")

--- a/src/main/kotlin/com/fesi/flowit/goal/repository/GoalQRepository.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/repository/GoalQRepository.kt
@@ -1,8 +1,13 @@
 package com.fesi.flowit.goal.repository
 
 import com.fesi.flowit.goal.dto.GoalFindAllResponseDto
+import com.fesi.flowit.goal.vo.GoalSummaryVo
+import com.fesi.flowit.goal.search.GoalWidgetCondition
 import com.fesi.flowit.user.entity.User
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 interface GoalQRepository {
     fun findAllGoalsByUser(user: User): List<GoalFindAllResponseDto>
+    fun searchGoals(user: User, cond: GoalWidgetCondition, pageable: Pageable): Page<GoalSummaryVo>
 }

--- a/src/main/kotlin/com/fesi/flowit/goal/repository/GoalQRepositoryImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/repository/GoalQRepositoryImpl.kt
@@ -3,10 +3,19 @@ package com.fesi.flowit.goal.repository
 import com.fesi.flowit.goal.dto.GoalFindAllResponseDto
 import com.fesi.flowit.goal.dto.QGoalFindAllResponseDto
 import com.fesi.flowit.goal.entity.QGoal
+import com.fesi.flowit.goal.search.GoalSortCriteria
+import com.fesi.flowit.goal.vo.GoalSummaryVo
+import com.fesi.flowit.goal.search.GoalWidgetCondition
 import com.fesi.flowit.user.entity.User
+import com.querydsl.core.types.OrderSpecifier
+import com.querydsl.core.types.Projections
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 class GoalQRepositoryImpl(
@@ -21,6 +30,61 @@ class GoalQRepositoryImpl(
             .where(isOwnedBy(user))
             .orderBy(goal.isPinned.desc())
             .fetch()
+    }
+
+    override fun searchGoals(user: User, cond: GoalWidgetCondition, pageable: Pageable): Page<GoalSummaryVo> {
+        val goals = queryFactory
+            .select(
+                Projections.constructor(
+                    GoalSummaryVo::class.java,
+                    goal.id,
+                    goal.name,
+                    goal.color,
+                    goal.createdDateTime,
+                    goal.dueDateTime,
+                    goal.isPinned
+                )
+            )
+            .from(goal)
+            .where(
+                isOwnedBy(user),
+                isOnlyPinned(cond.isPinned),
+                isNotExpireGoal()
+            )
+            .orderBy(orderByGoalSortCriteria(cond.sortedBy))
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        val totalCount = queryFactory
+            .select(goal.count())
+            .from(goal)
+            .where(
+                isOwnedBy(user),
+                isOnlyPinned(cond.isPinned),
+                isNotExpireGoal()
+            )
+            .fetchOne() ?: 0
+
+        return PageImpl(goals, pageable, totalCount)
+    }
+
+    private fun isOnlyPinned(isPinned: Boolean): BooleanExpression? {
+        return if (isPinned) {
+            goal.isPinned.eq(true)
+        } else {
+             null
+        }
+    }
+
+    private fun isNotExpireGoal(): BooleanExpression {
+        return goal.dueDateTime.goe(LocalDateTime.now())
+    }
+
+    private fun orderByGoalSortCriteria(cond: GoalSortCriteria): OrderSpecifier<LocalDateTime> {
+        return when (cond) {
+            GoalSortCriteria.LATEST -> goal.createdDateTime.desc()
+            GoalSortCriteria.DUE_DATE -> goal.dueDateTime.asc()
+        }
     }
 
     private fun isOwnedBy(user: User): BooleanExpression {

--- a/src/main/kotlin/com/fesi/flowit/goal/search/GoalSortCriteria.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/search/GoalSortCriteria.kt
@@ -1,0 +1,10 @@
+package com.fesi.flowit.goal.search
+
+enum class GoalSortCriteria(
+    private val description: String
+) {
+    LATEST("생성일 기준"),
+    DUE_DATE("마감일 기준"),
+
+    ;
+}

--- a/src/main/kotlin/com/fesi/flowit/goal/search/GoalWidgetCondition.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/search/GoalWidgetCondition.kt
@@ -1,0 +1,7 @@
+package com.fesi.flowit.goal.search
+
+data class GoalWidgetCondition(
+    val userId: Long,
+    val sortedBy: GoalSortCriteria,
+    val isPinned: Boolean
+)

--- a/src/main/kotlin/com/fesi/flowit/goal/service/GoalService.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/service/GoalService.kt
@@ -1,11 +1,14 @@
 package com.fesi.flowit.goal.service
 
+import com.fesi.flowit.common.response.PageResponse
 import com.fesi.flowit.goal.dto.GoalsByMonthlyResponseDto
 import com.fesi.flowit.goal.dto.GoalInfoResponseDto
 import com.fesi.flowit.goal.dto.GoalFindAllResponseDto
 import com.fesi.flowit.goal.dto.GoalSummaryResponseDto
 import com.fesi.flowit.goal.entity.Goal
+import com.fesi.flowit.goal.search.GoalWidgetCondition
 import com.fesi.flowit.user.entity.User
+import org.springframework.data.domain.Pageable
 import java.time.LocalDateTime
 import java.time.YearMonth
 
@@ -16,6 +19,7 @@ interface GoalService {
     fun getAllGoals(userId: Long): List<GoalFindAllResponseDto>
     fun getGoalById(goalId: Long): Goal
     fun doesNotUserOwnGoal(user: User, goal: Goal): Boolean
-    fun getGoalsSummaries(userId: Long): List<GoalSummaryResponseDto>
+    fun getGoalsSummariesInDashboard(userId: Long): List<GoalSummaryResponseDto>
     fun getGoalSummariesByDueYearMonth(userId: Long, dueYearMonth: YearMonth): GoalsByMonthlyResponseDto
+    fun searchGoalSummaries(cond: GoalWidgetCondition, pageable: Pageable): PageResponse<GoalSummaryResponseDto>
 }

--- a/src/main/kotlin/com/fesi/flowit/goal/vo/GoalSummaryVo.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/vo/GoalSummaryVo.kt
@@ -1,8 +1,9 @@
 package com.fesi.flowit.goal.vo
 
+import com.querydsl.core.annotations.QueryProjection
 import java.time.LocalDateTime
 
-data class GoalSummaryVo(
+data class GoalSummaryVo @QueryProjection constructor(
     val goalId: Long,
     val goalName: String,
     val color: String,


### PR DESCRIPTION
모든 목표 조회 API는 현재 배포되어 있는 API이므로 먼저 PR을 생성합니다.

요청을 받을 땐 Spring에서 제공하는 Pageable을 활용했습니다.
응답을 줄 땐 PageResponse를 활용하시면 됩니다. 이는 모든 페이징을 지원하는 API의 공통 Response 포맷입니다.
실제 데이터를 제네릭에 전달하여 사용하시면 될 것 같습니다.

