### PR TITLE
FEAT: 할 일 고정, 목표 완료, 목표 단 건 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/fesi/flowit/goal/controller/GoalController.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/controller/GoalController.kt
@@ -72,6 +72,33 @@ interface GoalController {
                    @RequestBody request: GoalModifyRequestDto): ResponseEntity<ApiResult<GoalInfoResponseDto>>
 
     @Operation(
+        summary = "목표 고정 상태 변경",
+        description = "목표 고정 상태를 변경합니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "목표 고정 상태 변경 성공",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = GoalChangePinResponseDto::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "올바르지 않은 요청 혹은 유효하지 않은 파라미터 값",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ApiResult.Exception::class)
+                )]
+            )
+        ]
+    )
+    fun changePinStatus(@PathVariable("goalId") goalId: Long,
+                        @RequestBody request: GoalChangePinRequestDto): ResponseEntity<ApiResult<GoalChangePinResponseDto>>
+
+    @Operation(
         summary = "목표 삭제",
         description = "목표를 삭제합니다. 목표에 포함된 할 일도 모두 삭제됩니다."
     )
@@ -139,7 +166,8 @@ interface GoalController {
                 description = "조회 성공",
                 content = [Content(
                     mediaType = "application/json",
-                    schema = Schema(implementation = GoalSummaryResponseDto::class)
+                    schema = Schema(implementation = PageResponse::class, subTypes = [GoalSummaryResponseDto::class])
+
                 )]
             ),
             ApiResponse(

--- a/src/main/kotlin/com/fesi/flowit/goal/controller/GoalController.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/controller/GoalController.kt
@@ -156,6 +156,33 @@ interface GoalController {
     fun getAllGoals(@RequestParam("userId") userId: Long): ResponseEntity<ApiResult<List<GoalFindAllResponseDto>>>
 
     @Operation(
+        summary = "목표 조회",
+        description = "목표를 조회합니다. 할 일 목록과 함께 반환됩니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "조회 성공",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = GoalSummaryResponseDto::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "올바르지 않은 요청 혹은 유효하지 않은 파라미터 값",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ApiResult.Exception::class)
+                )]
+            )
+        ]
+    )
+    fun getGoalSummary(@PathVariable("goalId") goalId: Long,
+                       @RequestParam("userId") userId: Long): ResponseEntity<ApiResult<GoalSummaryResponseDto>>
+
+    @Operation(
         summary = "모든 목표 조회",
         description = "모든 목표를 조건에 따라 탐색합니다."
     )
@@ -211,7 +238,7 @@ interface GoalController {
             )
         ]
     )
-    fun getGoalsInDashboard(@RequestParam("userId") userId: Long): ResponseEntity<ApiResult<List<GoalSummaryResponseDto>>>
+    fun getGoalSummariesInDashboard(@RequestParam("userId") userId: Long): ResponseEntity<ApiResult<List<GoalSummaryResponseDto>>>
 
     @Operation(
         summary = "월 별 목표 조회 (캘린더)",

--- a/src/main/kotlin/com/fesi/flowit/goal/controller/GoalControllerImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/controller/GoalControllerImpl.kt
@@ -81,24 +81,32 @@ class GoalControllerImpl(
 
     @GetMapping("/goals")
     override fun getAllGoals(@RequestParam("userId") userId: Long): ResponseEntity<ApiResult<List<GoalFindAllResponseDto>>> {
-        log.debug(">> request getAllGoals(userId=${userId}")
+        log.debug(">> request getAllGoals(userId=${userId})")
         return ApiResponse.ok(goalService.getAllGoals(userId))
     }
 
-    @GetMapping("/goals/dashboard")
-    override fun getGoalsInDashboard(@RequestParam("userId") userId: Long): ResponseEntity<ApiResult<List<GoalSummaryResponseDto>>> {
-        log.debug(">> request getGoalsInDashboard(userId=${userId}")
+    @GetMapping("/goals/{goalId}/summary")
+    override fun getGoalSummary(@PathVariable("goalId") goalId: Long,
+                       @RequestParam("userId") userId: Long): ResponseEntity<ApiResult<GoalSummaryResponseDto>> {
+        log.debug(">> request getGoalSummary(userId=${userId}, goalId=${goalId})")
+
+        return ApiResponse.ok(goalService.getGoalsSummary(userId, goalId))
+    }
+
+    @GetMapping("/goals/dashboard/summaries")
+    override fun getGoalSummariesInDashboard(@RequestParam("userId") userId: Long): ResponseEntity<ApiResult<List<GoalSummaryResponseDto>>> {
+        log.debug(">> request getGoalSummariesInDashboard(userId=${userId})")
         return ApiResponse.ok(goalService.getGoalsSummariesInDashboard(userId))
     }
 
-    @GetMapping("/goals/todos")
+    @GetMapping("/goals/summaries")
     override fun searchGoalSummaries(
         @RequestParam("userId") userId: Long,
         @RequestParam("isPinned") isPinned: Boolean,
         @RequestParam("sortedBy") sortedBy: GoalSortCriteria,
         pageable: Pageable
     ): ResponseEntity<ApiResult<PageResponse<GoalSummaryResponseDto>>> {
-        log.debug(">> request searchGoalSummaries(userId=${userId}, isPinned=${isPinned}, sortedBy=${sortedBy} page=${pageable}}")
+        log.debug(">> request searchGoalSummaries(userId=${userId}, isPinned=${isPinned}, sortedBy=${sortedBy} page=${pageable})")
 
         val searchCond = GoalWidgetCondition(userId, sortedBy, isPinned)
         return ApiResponse.ok(goalService.searchGoalSummaries(searchCond, pageable))
@@ -112,7 +120,7 @@ class GoalControllerImpl(
         @DateTimeFormat(pattern = "yyyy-MM")
         dueYearMonth: YearMonth
     ): ResponseEntity<ApiResult<GoalsByMonthlyResponseDto>> {
-        log.debug(">> request getGoalsByDueMonth(userId=${userId}")
+        log.debug(">> request getGoalsByDueMonth(userId=${userId})")
         return ApiResponse.ok(goalService.getGoalSummariesByDueYearMonth(userId, dueYearMonth))
     }
 }

--- a/src/main/kotlin/com/fesi/flowit/goal/controller/GoalControllerImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/controller/GoalControllerImpl.kt
@@ -60,6 +60,14 @@ class GoalControllerImpl(
         return ApiResponse.ok(result)
     }
 
+    @PatchMapping("/goals/{goalId}/pin")
+    override fun changePinStatus(@PathVariable("goalId") goalId: Long,
+                                 @RequestBody request: GoalChangePinRequestDto): ResponseEntity<ApiResult<GoalChangePinResponseDto>> {
+        log.debug(">> request changePinStatus(goalId=${goalId}, request=${request})")
+
+        return ApiResponse.ok(goalService.changePinStatus(goalId, request.userId, request.isPinned))
+    }
+
     @DeleteMapping("/goals/{goalId}")
     override fun deleteGoal(@PathVariable("goalId") goalId: Long,
                             @RequestParam("userId") userId: Long

--- a/src/main/kotlin/com/fesi/flowit/goal/dto/GoalChangePinRequestDto.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/dto/GoalChangePinRequestDto.kt
@@ -1,0 +1,25 @@
+package com.fesi.flowit.goal.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class GoalChangePinRequestDto(
+    @field:Schema(
+        description = "회원 ID",
+        example = "1",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    val userId: Long,
+
+    @field:Schema(
+        description = "고정 여부",
+        example = "true | false",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    val isPinned: Boolean
+) {
+    companion object {
+        fun of(userId: Long, isPinned: Boolean): GoalChangePinRequestDto {
+            return GoalChangePinRequestDto(userId, isPinned)
+        }
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/goal/dto/GoalChangePinResponseDto.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/dto/GoalChangePinResponseDto.kt
@@ -1,0 +1,23 @@
+package com.fesi.flowit.goal.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class GoalChangePinResponseDto(
+    @field:Schema(
+        description = "목표 ID",
+        example = "1",
+    )
+    var goalId: Long,
+
+    @field:Schema(
+        description = "고정 여부",
+        example = "true | false",
+    )
+    var isPinned: Boolean
+) {
+    companion object {
+        fun of(goalId: Long, isPinned: Boolean): GoalChangePinResponseDto {
+            return GoalChangePinResponseDto(goalId, isPinned)
+        }
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/goal/entity/Goal.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/entity/Goal.kt
@@ -21,7 +21,7 @@ class Goal private constructor(
     var color: String = "#000000",
 
     @Column(nullable = false)
-    val isPinned: Boolean = false,
+    var isPinned: Boolean = false,
 
     @CreatedDate
     @Column(nullable = false)

--- a/src/main/kotlin/com/fesi/flowit/goal/service/GoalService.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/service/GoalService.kt
@@ -17,7 +17,8 @@ interface GoalService {
     fun getAllGoals(userId: Long): List<GoalFindAllResponseDto>
     fun getGoalById(goalId: Long): Goal
     fun doesNotUserOwnGoal(user: User, goal: Goal): Boolean
+    fun getGoalsSummary(userId: Long, goalId: Long): GoalSummaryResponseDto
     fun getGoalsSummariesInDashboard(userId: Long): List<GoalSummaryResponseDto>
-    fun getGoalSummariesByDueYearMonth(userId: Long, dueYearMonth: YearMonth): GoalsByMonthlyResponseDto
     fun searchGoalSummaries(cond: GoalWidgetCondition, pageable: Pageable): PageResponse<GoalSummaryResponseDto>
+    fun getGoalSummariesByDueYearMonth(userId: Long, dueYearMonth: YearMonth): GoalsByMonthlyResponseDto
 }

--- a/src/main/kotlin/com/fesi/flowit/goal/service/GoalService.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/service/GoalService.kt
@@ -1,10 +1,7 @@
 package com.fesi.flowit.goal.service
 
 import com.fesi.flowit.common.response.PageResponse
-import com.fesi.flowit.goal.dto.GoalsByMonthlyResponseDto
-import com.fesi.flowit.goal.dto.GoalInfoResponseDto
-import com.fesi.flowit.goal.dto.GoalFindAllResponseDto
-import com.fesi.flowit.goal.dto.GoalSummaryResponseDto
+import com.fesi.flowit.goal.dto.*
 import com.fesi.flowit.goal.entity.Goal
 import com.fesi.flowit.goal.search.GoalWidgetCondition
 import com.fesi.flowit.user.entity.User
@@ -15,6 +12,7 @@ import java.time.YearMonth
 interface GoalService {
     fun createGoal(userId: Long, name: String, color: String, dueDateTime: LocalDateTime): GoalInfoResponseDto
     fun modifyGoal(goalId: Long, userId: Long, name: String, color: String, dueDateTime: LocalDateTime): GoalInfoResponseDto
+    fun changePinStatus(goalId: Long, userId: Long, isPinned: Boolean): GoalChangePinResponseDto
     fun deleteGoalById(userId: Long, goalId: Long)
     fun getAllGoals(userId: Long): List<GoalFindAllResponseDto>
     fun getGoalById(goalId: Long): Goal

--- a/src/main/kotlin/com/fesi/flowit/goal/service/GoalServiceImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/goal/service/GoalServiceImpl.kt
@@ -85,6 +85,21 @@ class GoalServiceImpl(
         return GoalInfoResponseDto.fromGoal(goal)
     }
 
+    @Transactional
+    override fun changePinStatus(goalId: Long, userId: Long, isPinned: Boolean): GoalChangePinResponseDto {
+        val user: User = userService.findUserById(userId)
+        val goal: Goal = getGoalById(goalId)
+
+        if (doesNotUserOwnGoal(user, goal)) {
+            throw GoalException.fromCode(ApiResultCode.GOAL_NOT_MATCH_USER)
+        }
+
+        goal.isPinned = isPinned
+        log.debug("Goal(id=${goalId}) is changed isPinned status to ${isPinned}")
+
+        return GoalChangePinResponseDto.of(goalId, isPinned)
+    }
+
     /**
      * 목표 삭제
      */

--- a/src/main/kotlin/com/fesi/flowit/todo/controller/TodoController.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/controller/TodoController.kt
@@ -1,10 +1,7 @@
 package com.fesi.flowit.todo.controller
 
 import com.fesi.flowit.common.response.ApiResult
-import com.fesi.flowit.todo.dto.TodoCreateRequestDto
-import com.fesi.flowit.todo.dto.TodoCreateResponseDto
-import com.fesi.flowit.todo.dto.TodoModifyRequestDto
-import com.fesi.flowit.todo.dto.TodoModifyResponseDto
+import com.fesi.flowit.todo.dto.*
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -69,6 +66,34 @@ interface TodoController {
     fun modifyTodo(@PathVariable("todoId") todoId: Long,
                    @RequestBody request: TodoModifyRequestDto
     ): ResponseEntity<ApiResult<TodoModifyResponseDto>>
+
+    @Operation(
+        summary = "할 일 완료 상태 변경",
+        description = "할 일 완료 상태를 변경합니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "할 일 완료 상태 변경 성공",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = TodoChangeDoneResponseDto::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "올바르지 않은 요청 혹은 유효하지 않은 파라미터 값",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ApiResult.Exception::class)
+                )]
+            )
+        ]
+    )
+    fun changeDoneStatus(@PathVariable("todoId") todoId: Long,
+                         @RequestBody request: TodoChangeDoneRequestDto
+    ): ResponseEntity<ApiResult<TodoChangeDoneResponseDto>>
 
     @Operation(
         summary = "할 일 삭제",

--- a/src/main/kotlin/com/fesi/flowit/todo/controller/TodoControllerImpl.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/controller/TodoControllerImpl.kt
@@ -3,10 +3,7 @@ package com.fesi.flowit.todo.controller
 import com.fesi.flowit.common.logging.loggerFor
 import com.fesi.flowit.common.response.ApiResponse
 import com.fesi.flowit.common.response.ApiResult
-import com.fesi.flowit.todo.dto.TodoCreateRequestDto
-import com.fesi.flowit.todo.dto.TodoCreateResponseDto
-import com.fesi.flowit.todo.dto.TodoModifyRequestDto
-import com.fesi.flowit.todo.dto.TodoModifyResponseDto
+import com.fesi.flowit.todo.dto.*
 import com.fesi.flowit.todo.service.TodoService
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
@@ -40,6 +37,14 @@ class TodoControllerImpl(
         )
 
         return ApiResponse.ok(result)
+    }
+
+    @PatchMapping("/todos/{todoId}/done")
+    override fun changeDoneStatus(@PathVariable("todoId") todoId: Long,
+                                  @RequestBody request: TodoChangeDoneRequestDto): ResponseEntity<ApiResult<TodoChangeDoneResponseDto>> {
+        log.debug(">> request changeDoneStatus(todoId=${todoId}, request=${request}")
+
+        return ApiResponse.ok(todoService.changeDoneStatus(todoId, request.userId, request.isDone))
     }
 
     @DeleteMapping("/todos/{todoId}")

--- a/src/main/kotlin/com/fesi/flowit/todo/dto/TodoChangeDoneRequestDto.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/dto/TodoChangeDoneRequestDto.kt
@@ -1,0 +1,25 @@
+package com.fesi.flowit.todo.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class TodoChangeDoneRequestDto(
+    @field:Schema(
+        description = "회원 ID",
+        example = "1",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    var userId: Long,
+
+    @field:Schema(
+        description = "완료 여부",
+        example = "true | false",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    var isDone: Boolean
+) {
+    companion object {
+        fun of(userId: Long, isDone: Boolean): TodoChangeDoneRequestDto {
+            return TodoChangeDoneRequestDto(userId, isDone)
+        }
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/todo/dto/TodoChangeDoneResponseDto.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/dto/TodoChangeDoneResponseDto.kt
@@ -1,0 +1,23 @@
+package com.fesi.flowit.todo.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class TodoChangeDoneResponseDto(
+    @field:Schema(
+        description = "할 일 ID",
+        example = "1",
+    )
+    var todoId: Long,
+
+    @field:Schema(
+        description = "완료 여부",
+        example = "true | false",
+    )
+    var isDone: Boolean
+) {
+    companion object {
+        fun of(todoId: Long, isDone: Boolean): TodoChangeDoneResponseDto {
+            return TodoChangeDoneResponseDto(todoId, isDone)
+        }
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/todo/entity/Todo.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/entity/Todo.kt
@@ -18,7 +18,7 @@ class Todo private constructor(
     var name: String,
 
     @Column(nullable = false)
-    val isDone: Boolean = false,
+    var isDone: Boolean = false,
 
     @CreatedDate
     @Column(nullable = false)

--- a/src/main/kotlin/com/fesi/flowit/todo/service/TodoService.kt
+++ b/src/main/kotlin/com/fesi/flowit/todo/service/TodoService.kt
@@ -1,5 +1,6 @@
 package com.fesi.flowit.todo.service
 
+import com.fesi.flowit.todo.dto.TodoChangeDoneResponseDto
 import com.fesi.flowit.todo.dto.TodoCreateResponseDto
 import com.fesi.flowit.todo.dto.TodoModifyResponseDto
 import com.fesi.flowit.todo.entity.Todo
@@ -7,6 +8,7 @@ import com.fesi.flowit.todo.entity.Todo
 interface TodoService {
     fun createTodo(userId: Long, name: String, goalId: Long): TodoCreateResponseDto
     fun modifyTodo(todoId: Long, userId: Long, name: String, goalId: Long): TodoModifyResponseDto
+    fun changeDoneStatus(todoId: Long, userId: Long, isDone: Boolean): TodoChangeDoneResponseDto
     fun deleteTodoById(userId: Long, todoId: Long)
     fun getTodosByIds(todoIds: List<Long>): List<Todo>
 }


### PR DESCRIPTION
추가 API 배포가 필요함에 따라 바로 반영하겠습니다.

참고로 목표 단 건 조회는 Lazy Loading으로 인해 연관 객체가 프록시 객체 상태입니다.
이후 QueryDSL로 넘어갈 때 수정 예정이며 우선 트랜잭션으로 처리합니다.