### PR TITLE
[FIX] 토큰 없이 API 요청 시 403 대신 401을 반환

### DIFF
--- a/src/main/kotlin/com/fesi/flowit/common/config/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/config/CustomAccessDeniedHandler.kt
@@ -1,0 +1,42 @@
+package com.fesi.flowit.common.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fesi.flowit.common.response.ApiResult
+import com.fesi.flowit.common.response.ApiResultCode
+import com.fesi.flowit.common.response.exceptions.AuthException
+import com.fesi.flowit.common.response.exceptions.BaseException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.stereotype.Component
+
+@Component
+class CustomAccessDeniedHandler(
+    private val objectMapper: ObjectMapper
+) : AccessDeniedHandler {
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException
+    ) {
+        val e = AuthException(code = ApiResultCode.FORBIDDEN, httpStatus = HttpStatus.FORBIDDEN)
+        val apiResult = ApiResult.Exception<AuthException>(
+            code = e.code.code,
+            message = e.message,
+            httpStatus = e.httpStatus
+        )
+        handleException(response, apiResult)
+    }
+
+    private fun handleException(
+        response: HttpServletResponse,
+        apiResult: ApiResult<BaseException>
+    ) {
+        response.status = apiResult.httpStatus.value()
+        response.contentType = "application/json"
+        response.characterEncoding = "UTF-8"
+        response.writer.write(objectMapper.writeValueAsString(apiResult))
+    }
+}

--- a/src/main/kotlin/com/fesi/flowit/common/config/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/config/CustomAuthenticationEntryPoint.kt
@@ -1,0 +1,39 @@
+package com.fesi.flowit.common.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fesi.flowit.common.response.ApiResult
+import com.fesi.flowit.common.response.ApiResultCode
+import com.fesi.flowit.common.response.exceptions.AuthException
+import com.fesi.flowit.common.response.exceptions.BaseException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+
+@Component
+class CustomAuthenticationEntryPoint(
+    private val objectMapper: ObjectMapper
+) : AuthenticationEntryPoint {
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        val e = AuthException.fromCode(ApiResultCode.UNAUTHORIZED)
+        val apiResult = ApiResult.Exception<AuthException>(
+            code = e.code.code,
+            message = e.message,
+            httpStatus = e.httpStatus
+        )
+        handleException(response, apiResult)
+    }
+
+    private fun handleException(response: HttpServletResponse, apiResult: ApiResult<BaseException>) {
+        response.status = apiResult.httpStatus.value()
+        response.contentType = "application/json"
+        response.characterEncoding = "UTF-8"
+        response.writer.write(objectMapper.writeValueAsString(apiResult))
+    }
+
+}

--- a/src/main/kotlin/com/fesi/flowit/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/config/SecurityConfig.kt
@@ -18,7 +18,9 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
-    private val jwtAuthenticationFilter: JwtAuthenticationFilter
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val accessDeniedHandler: CustomAccessDeniedHandler,
+    private val authenticationEntryPoint: CustomAuthenticationEntryPoint
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
@@ -35,6 +37,10 @@ class SecurityConfig(
                         "/api-doc/**"
                     ).permitAll()
                     .anyRequest().authenticated()
+            }
+            .exceptionHandling {
+                it.authenticationEntryPoint(authenticationEntryPoint)
+                    .accessDeniedHandler(accessDeniedHandler)
             }
             .addFilterBefore(
                 jwtAuthenticationFilter,

--- a/src/main/kotlin/com/fesi/flowit/common/response/ApiResultCode.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/ApiResultCode.kt
@@ -13,6 +13,7 @@ enum class ApiResultCode(
     CREATED("0201", "Created"),
     BAD_REQUEST("0400", "Bad Request"),
     UNAUTHORIZED("0401", "Unauthorized"),
+    FORBIDDEN("0403", "Forbidden"),
     CONFLICT("0409", "Conflict"),
     INTERNAL_ERROR("0500", "Unexpected Error"),
   

--- a/src/main/kotlin/com/fesi/flowit/common/response/exceptions/AuthException.kt
+++ b/src/main/kotlin/com/fesi/flowit/common/response/exceptions/AuthException.kt
@@ -1,0 +1,20 @@
+package com.fesi.flowit.common.response.exceptions
+
+import com.fesi.flowit.common.response.ApiResultCode
+import org.springframework.http.HttpStatus
+
+class AuthException(
+    override val code: ApiResultCode,
+    override val httpStatus: HttpStatus = HttpStatus.UNAUTHORIZED,
+    override val message: String = code.message
+) : BaseException(code, httpStatus) {
+    companion object {
+        fun fromCode(code: ApiResultCode): AuthException {
+            return AuthException(code = code, message = code.message)
+        }
+
+        fun fromCodeWithMsg(code: ApiResultCode, msg: String): AuthException {
+            return AuthException(code = code, message = msg)
+        }
+    }
+}


### PR DESCRIPTION
토큰 없이 API 요청 시 403 대신 401을 반환합니다.