### PR TITLE
로그인, 재발급 시 리프레시 토큰을 항상 반환

### DIFF
--- a/src/main/kotlin/com/fesi/flowit/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/fesi/flowit/auth/service/AuthService.kt
@@ -33,7 +33,7 @@ class AuthService(
         val authenticationToken = UsernamePasswordAuthenticationToken(dto.email, dto.password)
 
         val accessTokenAndExpiresIn: Pair<String, Long>
-        val refreshToken: String?
+        val refreshToken: String
         val authentication: Authentication
         try {
             authentication = authenticationManager.authenticate(authenticationToken)
@@ -43,15 +43,11 @@ class AuthService(
             throw AuthException.fromCode(ApiResultCode.UNAUTHORIZED)
         }
 
-        var response = SignInResponse.of(
+        return SignInResponse.of(
             authentication.principal as User,
             accessTokenAndExpiresIn.first,
             accessTokenAndExpiresIn.second
-        )
-        if (refreshToken != null) {
-            response = response.with(refreshToken = refreshToken)
-        }
-        return response
+        ).with(refreshToken = refreshToken)
     }
 
     /**
@@ -68,10 +64,7 @@ class AuthService(
         val (newAccessToken, expiresIn) = jwtGenerator.generateToken(authentication)
         val newRefreshToken = jwtGenerator.handleRefreshTokenWith(refreshToken)
 
-        var response = RegenerateResponse.of(accessToken = newAccessToken, expiresIn = expiresIn)
-        if (newRefreshToken != null) {
-            response = response.with(refreshToken = newRefreshToken)
-        }
-        return response
+        return RegenerateResponse.of(accessToken = newAccessToken, expiresIn = expiresIn)
+            .with(refreshToken = newRefreshToken)
     }
 }

--- a/src/main/kotlin/com/fesi/flowit/auth/service/JwtGenerator.kt
+++ b/src/main/kotlin/com/fesi/flowit/auth/service/JwtGenerator.kt
@@ -55,7 +55,7 @@ class JwtGenerator(
      * 로그인 시 리프레시 토큰 처리
      * 리프레시 토큰이 있을 경우, 토큰 재발급 시 쓰는 handleRefreshTokenWith()에 처리를 위임한다
      */
-    fun handleRefreshToken(authentication: Authentication): String? {
+    fun handleRefreshToken(authentication: Authentication): String {
         val principal = authentication.principal as User
 
         if (!isRefreshTokenExists(principal.id)) {
@@ -71,7 +71,7 @@ class JwtGenerator(
     /**
      * 토큰 재발급 시 리프레시 토큰 처리
      */
-    fun handleRefreshTokenWith(oldRefreshToken: String): String? {
+    fun handleRefreshTokenWith(oldRefreshToken: String): String {
         val unpack = jwtProcessor.unpackRefreshToken(oldRefreshToken)
 
         if (!isRefreshTokenExistsWith(oldRefreshToken)) {
@@ -81,7 +81,7 @@ class JwtGenerator(
         }
 
         if (!isRefreshTokenIsAboutTobeExpired(oldRefreshToken)) {
-            return null
+            return oldRefreshToken
         }
 
         if (isRefreshTokenExpired(oldRefreshToken)) {

--- a/src/test/kotlin/com/fesi/flowit/auth/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/fesi/flowit/auth/service/AuthServiceTest.kt
@@ -89,11 +89,11 @@ class AuthServiceTest : StringSpec({
         hasUserDetails(authentication)
         refreshTokenRepository.canFindTokenByUserId(tokenValue = "refresh_token")
         every { jwtGenerator.generateToken(any()) } returns Pair("newAccessToken", 3600)
-        every { jwtGenerator.handleRefreshTokenWith(any()) } returns null
+        every { jwtGenerator.handleRefreshTokenWith(any()) } returns "refresh_token"
 
         val response = service.regenerate("refresh_token")
         response.accessToken shouldNotBe  null
-        response.refreshToken shouldBe null
+        response.refreshToken shouldNotBe null
     }
 
     "토큰 재발급 시 새로운 access token과 refresh token을 생성한다" {


### PR DESCRIPTION
 - 기존 로직에서는 이전에 발급한 리프레시 토큰이 revoke되지 않았다면 만료일 일정 시점 전까지는 리프레시 토큰을 반환하지 않았습니다. 하지만 이 구현대로라면 앞과 같은 상황에서 다른 기기로 로그인을 시도할 경우 리프레시 토큰을 얻을 수 없기 때문에 문제가 됩니다.
 - 따라서 로그인, 재발급 요청마다 항상 리프레시 토큰을 반환합니다. 이때 매번 새로 만드는 대신, 유효한 리프레시 토큰이 db에 있을 경우는 해당 리프레시 토큰을 그대로 클라이언트에 반환합니다.
 - handleRefreshToken()과 handleRefreshToken()이 null을 반환하는 경우가 없어졌습니다. 이를 연관된 로직에 반영합니다.